### PR TITLE
docs(http-module) fix method name

### DIFF
--- a/content/techniques/http-module.md
+++ b/content/techniques/http-module.md
@@ -68,7 +68,7 @@ Quite often you might want to asynchronously pass your module options instead of
 First possible approach is to use a factory function:
 
 ```typescript
-HttpModule.forRootAsync({
+HttpModule.registerAsync({
   useFactory: () => ({
     timeout: 5000,
     maxRedirects: 5,
@@ -79,7 +79,7 @@ HttpModule.forRootAsync({
 Obviously, our factory behaves like every other one (might be `async` and is able to inject dependencies through `inject`).
 
 ```typescript
-HttpModule.forRootAsync({
+HttpModule.registerAsync({
   imports: [ConfigModule],
   useFactory: async (configService: ConfigService) => ({
     timeout: configService.getString('HTTP_TIMEOUT'),
@@ -92,7 +92,7 @@ HttpModule.forRootAsync({
 Alternatively, you are able to use class instead of a factory.
 
 ```typescript
-HttpModule.forRootAsync({
+HttpModule.registerAsync({
   useClass: HttpConfigService,
 });
 ```
@@ -114,7 +114,7 @@ class HttpConfigService implements HttpOptionsFactory {
 In order to prevent the creation of `HttpConfigService` inside `HttpModule` and use a provider imported from a different module, you can use the `useExisting` syntax.
 
 ```typescript
-HttpModule.forRootAsync({
+HttpModule.registerAsync({
   imports: [ConfigModule],
   useExisting: ConfigService,
 });


### PR DESCRIPTION
The method `forRootAsync` does not exist on the class `HttpModule`. Fixing docs for the correct method: `registerAsync`

I'm not pretty sure. But maybe `forRootAsync` should be more consistent

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] Other... Please describe:

Documentation mismatch
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information